### PR TITLE
Add spoilers functionality

### DIFF
--- a/docs/en/_static/spoilers.js
+++ b/docs/en/_static/spoilers.js
@@ -1,0 +1,43 @@
+(function ($) {
+    'use strict';
+    $.fn.showHide = function (options) {
+
+        //default vars for the plugin
+        var defaults = {
+            speed: 500,
+            easing: '',
+            changeText: true,
+            showText: 'Show',
+            hideText: 'Hide'
+
+        };
+        options = $.extend(defaults, options);
+
+        $(this).hide().data('hidden', true);
+
+        $(this).after('<button class="_show_hide" type="button">' + options.showText + '</button>');
+
+        $('._show_hide').click(function () {
+            var me = $(this);
+            var el = $(this).prev();
+            el.slideToggle(options.speed, function() {
+                if (options.changeText) {
+                    if (el.data('hidden')) {
+                        el.data('hidden', false);
+                        me.text(options.hideText);
+                    } else {
+                        el.data('hidden', true);
+                        me.text(options.showText);
+                    }
+                }
+            });
+        });
+    };
+})(jQuery);
+
+(function ($) {
+  $(document).ready(function() {
+    'use strict';
+    $("h3:contains('Solution')").next().showHide();
+  });
+})(jQuery);

--- a/docs/en/_templates/layout.html
+++ b/docs/en/_templates/layout.html
@@ -1,0 +1,2 @@
+{% extends "!layout.html" %}
+{% set script_files = script_files + ["_static/spoilers.js"] %}


### PR DESCRIPTION
Now all solutions are hidden and must be shown
- Used _templates/layout.html to added a javascript file
- Used _static/spoilers.js that will select all code boxes
  after a h3 containing 'Solution' and hide them, with a show button.

Example: http://embed.plnkr.co/fR7Sd6DCQ3Jxzimjvfqj
