### PR TITLE
Modernize layout

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,6 +33,7 @@ need to have the following Python packages installed:
 - Sphinx (and its dependencies docutils and Pygments)
 - Fabric
 - sphinx-intl
+- sphinx-bootstrap-theme
 
 You can install these with pip using ``pip install -r requirements.txt``
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Fabric
 Sphinx
 sphinx-intl
+sphinx-bootstrap-theme

--- a/source/_static/custom.css
+++ b/source/_static/custom.css
@@ -52,3 +52,31 @@ pre {
 div.sphinxsidebar {
     font-size: 0.8em;
 }
+div.related {
+    background-color: #085987;
+}
+div.related a {
+    color: white;
+}
+.navbar-version b {
+    font-weight: lighter;
+    color: #76B3D6;
+}
+.navbar-version b:before {
+    content: "v";
+}
+.navbar-rel .glyphicon {
+    font-size: 0.9em;
+}
+#navbar {
+    background-image: linear-gradient(to bottom, #085987 0px, #2fb0d5 100%);
+}
+.navbar>.container .navbar-brand,
+.navbar-default .navbar-nav>li>a {
+    color: white !important;
+}
+.navbar-default .navbar-nav>.open>a,
+.navbar-default .navbar-nav>.open>a:hover,
+.navbar-default .navbar-nav>.open>a:focus {
+    background-color: #1F8AB6 !important;
+}

--- a/source/_static/spoilers.js
+++ b/source/_static/spoilers.js
@@ -15,7 +15,7 @@
 
         $(this).hide().data('hidden', true);
 
-        $(this).last().after('<button class="btn btn-warning _show_hide" type="button">' + options.showText + '</button>');
+        $(this).last().after('<button class="btn btn-info btn-sm _show_hide" type="button">' + options.showText + '</button>');
 
         $('._show_hide').click(function () {
             var me = $(this);

--- a/source/_templates/navbartoc.html
+++ b/source/_templates/navbartoc.html
@@ -1,0 +1,10 @@
+<li class="dropdown">
+  <a role="button"
+     id="dLabelLocalToc"
+     data-toggle="dropdown"
+     data-target="#"
+     href="#">{{ _('Chapter') }} <b class="caret"></b></a>
+  <ul class="dropdown-menu localtoc"
+      role="menu"
+      aria-labelledby="dLabelLocalToc">{{ toc }}</ul>
+</li>

--- a/source/_templates/relations.html
+++ b/source/_templates/relations.html
@@ -1,0 +1,16 @@
+{%- if prev %}
+  <li class="navbar-rel">
+    <a href="{{ prev.link|e }}" title="{{ _('Previous Chapter: ') + prev.title|striptags }}">
+      <span class="glyphicon glyphicon-step-backward"></span>
+      <span>{{ _('Previous') }}</span>
+    </a>
+  </li>
+{%- endif %}
+{%- if next %}
+  <li class="navbar-rel">
+    <a href="{{ next.link|e }}" title="{{ _('Next Chapter: ') + next.title|striptags }}">
+        <span class="glyphicon glyphicon-step-forward"></span>
+        <span>{{ _('Next') }}</span>
+    </a>
+  </li>
+{%- endif %}

--- a/source/_templates/sourcelink.html
+++ b/source/_templates/sourcelink.html
@@ -1,6 +1,5 @@
 {%- if has_source %}
-  <h3>{{ _('This Page') }}</h3>
-  <ul class="this-page-menu">
+  <ul id="sourcelink" class="list-inline">
 {%- if show_source and sourcename %}
     <li><a href="{{ pathto('_sources/' + sourcename, true)|e }}"
            rel="nofollow">{{ _('Show Source') }}</a></li>

--- a/source/conf.py
+++ b/source/conf.py
@@ -100,15 +100,20 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'nature'
+html_theme = 'bootstrap'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-#html_theme_options = {}
+html_theme_options = dict(
+        navbar_title = "Python for beginners",
+        navbar_site_name = "Material",
+        source_link_position = "footer",
+)
 
 # Add any paths that contain custom themes here, relative to this directory.
-#html_theme_path = []
+import sphinx_bootstrap_theme
+html_theme_path = sphinx_bootstrap_theme.get_html_theme_path()
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".


### PR DESCRIPTION
I suggest we use sphinx-bootstrap-theme to give our "Introduction to Programming with Python" a newer, fancier look.  It's going to look like this:
![pybeginners-bootstrap](https://cloud.githubusercontent.com/assets/33013/2654179/308760a6-bfce-11e3-91c4-46df16981a9c.png)

The Sphinx theme also supports using [Bootswatch](http://bootswatch.com/).
